### PR TITLE
use secp256k1 library with system 

### DIFF
--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -17,7 +17,7 @@ static void freePubkeyArray(secp256k1_pubkey **a) {
         free(a);
 }
 */
-// #cgo LDFLAGS: -lsecp256k1 -lstdc++ -lm -lz -lbz2
+// #cgo LDFLAGS: -lsecp256k1
 import "C"
 
 import (

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -17,7 +17,7 @@ static void freePubkeyArray(secp256k1_pubkey **a) {
         free(a);
 }
 */
-// #cgo LDFLAGS: -lsecp256k1
+// #cgo LDFLAGS: -lsecp256k1 -lstdc++ -lm -lz -lbz2 -lsnappy
 import "C"
 
 import (

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -1,9 +1,9 @@
 package secp256k1
 
 // #include <stdlib.h>
-// #include "c-secp256k1/include/secp256k1.h"
-// #include "c-secp256k1/include/secp256k1_ecdh.h"
-// #include "c-secp256k1/include/secp256k1_recovery.h"
+// #include "secp256k1.h"
+// #include "secp256k1_ecdh.h"
+// #include "secp256k1_recovery.h"
 /*
 // https://groups.google.com/forum/#!topic/golang-nuts/pQueMFdY0mk
 // for secp256k1_pubkey**

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -17,7 +17,7 @@ static void freePubkeyArray(secp256k1_pubkey **a) {
         free(a);
 }
 */
-// #cgo LDFLAGS: ${SRCDIR}/c-secp256k1/.libs/libsecp256k1.a -lgmp
+// #cgo LDFLAGS: libsecp256k1.a -lgmp
 import "C"
 
 import (

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -17,7 +17,7 @@ static void freePubkeyArray(secp256k1_pubkey **a) {
         free(a);
 }
 */
-// #cgo LDFLAGS: -lsecp256k1 -lstdc++ -lm -lz -lbz2 -lsnappy
+// #cgo LDFLAGS: -lsecp256k1 -lstdc++ -lm -lz -lbz2
 import "C"
 
 import (

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -17,7 +17,7 @@ static void freePubkeyArray(secp256k1_pubkey **a) {
         free(a);
 }
 */
-// #cgo LDFLAGS: libsecp256k1.a -lgmp
+// #cgo LDFLAGS: -lsecp256k1 -lgmp
 import "C"
 
 import (

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -17,7 +17,7 @@ static void freePubkeyArray(secp256k1_pubkey **a) {
         free(a);
 }
 */
-// #cgo LDFLAGS: -lsecp256k1 -lgmp
+// #cgo LDFLAGS: -lsecp256k1
 import "C"
 
 import (


### PR DESCRIPTION
Used in the system of library . not local library 
So secp256k1-go no longer need to use submodule[https://github.com/bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1) , We can use the secp256k1-go as a cgo library . Users need to compile their own installation secp256k1(c)
